### PR TITLE
Allow passing arbitrary atrribues to account creation

### DIFF
--- a/lib/zimbra/account.rb
+++ b/lib/zimbra/account.rb
@@ -15,7 +15,7 @@ module Zimbra
 
       def create(options)
         account = new(options)
-        AccountService.create(account) 
+        AccountService.create(account)
       end
 
       def acl_name
@@ -23,7 +23,7 @@ module Zimbra
       end
     end
 
-    attr_accessor :id, :name, :password, :acls, :cos_id, :delegated_admin
+    attr_accessor :id, :name, :password, :acls, :cos_id, :delegated_admin, :attributes
 
     def initialize(options = {})
       self.id = options[:id]
@@ -32,10 +32,11 @@ module Zimbra
       self.acls = options[:acls] || []
       self.cos_id = (options[:cos] ? options[:cos].id : options[:cos_id])
       self.delegated_admin = options[:delegated_admin]
+      self.attributes = options[:attributes] || []
     end
 
     def delegated_admin=(val)
-      @delegated_admin = Zimbra::Boolean.read(val) 
+      @delegated_admin = Zimbra::Boolean.read(val)
     end
     def delegated_admin?
       @delegated_admin
@@ -84,7 +85,7 @@ module Zimbra
         Builder.modify(message, account)
       end
       Parser.account_response(xml/'//n2:account')
-    end 
+    end
 
     def delete(dist)
       xml = invoke("n2:DeleteAccountRequest") do |message|
@@ -98,8 +99,11 @@ module Zimbra
           message.add 'name', account.name
           message.add 'password', account.password
           A.inject(message, 'zimbraCOSId', account.cos_id)
+          account.attributes.each do |k,v|
+            A.inject(message, k, v)
+          end
         end
-        
+
         def get_by_id(message, id)
           message.add 'account', id do |c|
             c.set_attr 'by', 'id'

--- a/lib/zimbra/account.rb
+++ b/lib/zimbra/account.rb
@@ -19,7 +19,7 @@ module Zimbra
       end
 
       def acl_name
-        'account'
+        'usr'
       end
     end
 

--- a/lib/zimbra/account.rb
+++ b/lib/zimbra/account.rb
@@ -49,6 +49,10 @@ module Zimbra
     def delete
       AccountService.delete(self)
     end
+
+    def add_alias(alias_name)
+      AccountService.add_alias(self,alias_name)
+    end
   end
 
   class AccountService < HandsoapService
@@ -93,6 +97,12 @@ module Zimbra
       end
     end
 
+    def add_alias(account,alias_name)
+      xml = invoke('n2:AddAccountAliasRequest') do |message|
+        Builder.add_alias(message,account.id,alias_name)
+      end
+    end
+
     class Builder
       class << self
         def create(message, account)
@@ -134,6 +144,11 @@ module Zimbra
 
         def delete(message, id)
           message.add 'id', id
+        end
+
+        def add_alias(message,id,alias_name)
+          message.add 'id', id
+          message.add 'alias', alias_name
         end
       end
     end

--- a/lib/zimbra/acl.rb
+++ b/lib/zimbra/acl.rb
@@ -2,7 +2,7 @@ module Zimbra
   class ACL
     class TargetObjectNotFound < StandardError; end
 
-    TARGET_CLASSES = [Zimbra::Domain, Zimbra::DistributionList, Zimbra::Cos]
+    TARGET_CLASSES = [Zimbra::Domain, Zimbra::DistributionList, Zimbra::Cos, Zimbra::Account]
     TARGET_MAPPINGS = TARGET_CLASSES.inject({}) do |hsh, klass|
       hsh[klass.acl_name] = klass
       hsh[klass] = klass.acl_name
@@ -51,7 +51,7 @@ module Zimbra
     def to_zimbra_acl_value
       id = target_id
       type = target_class.acl_name
-      "#{id} #{type} #{name}" 
+      "#{id} #{type} #{name}"
     end
 
     def apply(xmldoc)

--- a/lib/zimbra/distribution_list.rb
+++ b/lib/zimbra/distribution_list.rb
@@ -46,7 +46,7 @@ module Zimbra
     end
 
     def admin_group=(val)
-      @admin_group = Zimbra::Boolean.read(val) 
+      @admin_group = Zimbra::Boolean.read(val)
     end
     def admin_group?
       @admin_group
@@ -54,6 +54,10 @@ module Zimbra
 
     def delete
       DistributionListService.delete(self)
+    end
+
+    def add_alias(alias_name)
+      DistributionListService.add_alias(self,alias_name)
     end
 
     def save
@@ -97,7 +101,7 @@ module Zimbra
       Parser.distribution_list_response(xml/'//n2:dl')
 
       modify_members(dist)
-    end 
+    end
 
     def modify_members(distribution_list)
       distribution_list.new_members.each do |member|
@@ -123,6 +127,12 @@ module Zimbra
     def delete(dist)
       xml = invoke("n2:DeleteDistributionListRequest") do |message|
         Builder.delete(message, dist.id)
+      end
+    end
+
+    def add_alias(distribution_list,alias_name)
+      xml = invoke('n2:AddDistributionListAliasRequest') do |message|
+        Builder.add_alias(message,distribution_list.id,alias_name)
       end
     end
 
@@ -180,6 +190,11 @@ module Zimbra
 
         def delete(message, id)
           message.add 'id', id
+        end
+
+        def add_alias(message,id,alias_name)
+          message.add 'id', id
+          message.add 'alias', alias_name
         end
       end
     end

--- a/lib/zimbra/domain.rb
+++ b/lib/zimbra/domain.rb
@@ -14,7 +14,7 @@ module Zimbra
       end
 
       def create(name, attributes = {})
-        DomainService.create(name, attributes) 
+        DomainService.create(name, attributes)
       end
 
       def acl_name
@@ -25,7 +25,7 @@ module Zimbra
     attr_accessor :id, :name, :acls
 
     def initialize(id, name, acls = [])
-      self.id = id 
+      self.id = id
       self.name = name
       self.acls = acls || []
     end
@@ -38,7 +38,7 @@ module Zimbra
       DomainService.delete(self)
     end
   end
-  
+
   class DomainService < HandsoapService
     def all
       xml = invoke("n2:GetAllDomainsRequest")
@@ -47,7 +47,7 @@ module Zimbra
 
     def create(name, attributes = {})
       xml = invoke("n2:CreateDomainRequest") do |message|
-        Builder.create(message, name)
+        Builder.create(message, name, attributes)
       end
       Parser.domain_response(xml/"//n2:domain")
     end
@@ -73,7 +73,7 @@ module Zimbra
         Builder.modify(message, domain)
       end
       Parser.domain_response(xml/'//n2:domain')
-    end 
+    end
 
     def delete(dist)
       xml = invoke("n2:DeleteDomainRequest") do |message|
@@ -83,10 +83,14 @@ module Zimbra
 
     class Builder
       class << self
-        def create(message, name)
+        def create(message, name, attributes = {})
           message.add 'name', name
+          attributes.each do |k,v|
+            A.inject(message, k, v)
+          end
+          p message
         end
-        
+
         def get_by_id(message, id)
           message.add 'domain', id do |c|
             c.set_attr 'by', 'id'
@@ -130,7 +134,7 @@ module Zimbra
           id = (node/'@id').to_s
           name = (node/'@name').to_s
           acls = Zimbra::ACL.read(node)
-          Zimbra::Domain.new(id, name, acls) 
+          Zimbra::Domain.new(id, name, acls)
         end
       end
     end

--- a/lib/zimbra/domain.rb
+++ b/lib/zimbra/domain.rb
@@ -88,7 +88,6 @@ module Zimbra
           attributes.each do |k,v|
             A.inject(message, k, v)
           end
-          p message
         end
 
         def get_by_id(message, id)


### PR DESCRIPTION
The change allows you to pass arbitrary attributes when creating an account, that is:

``` ruby

Zimbra::Account.create({name: 'bob@example.com', 
                                       password: 'xxxxxxx',
                                       attributes: { displayName: 'Bob Smith', gn: 'Bob', sn: 'Smith'}
                                       })
```
